### PR TITLE
Fix infinite loop in light-dark mixin

### DIFF
--- a/postcss-light-dark.js
+++ b/postcss-light-dark.js
@@ -46,8 +46,8 @@ module.exports = () => {
     Once(root) {
       root.walkDecls((decl) => {
         const { value, prop } = decl;
-
-        if (value.includes('light-dark')) {
+        const regex = /\blight-dark\b/;
+        if (regex.test(value)) {
           const { light: lightVal, dark: darkVal } = getLightDarkValue(value);
           const darkMixin = postcss.atRule({ name: 'mixin', params: 'dark' });
           darkMixin.append(postcss.decl({ prop, value: darkVal }));


### PR DESCRIPTION
## Problem 
The `value.includes('light-dark')` check was catching the string `highlight-dark` in Monaco Editor, causing postcss to run in an infinite loop.

![image](https://github.com/mantinedev/postcss-preset-mantine/assets/99560876/ca822b55-bef1-4f59-af51-75f9a4f10e66)

## Solution
Change the check to a regex testing against the string `light-dark`

## Test
![image](https://github.com/mantinedev/postcss-preset-mantine/assets/99560876/5837e80f-2a34-452d-83f2-3e9bc0d8b2e7)

