### PR TITLE
Fix postcss.parse warning

### DIFF
--- a/src/postcss-light-dark.ts
+++ b/src/postcss-light-dark.ts
@@ -50,7 +50,7 @@ module.exports = () => {
 
     Once(root: Root) {
       root.walkDecls((decl) => {
-        const { value, prop } = decl;
+        const { value } = decl;
         const regex = /\blight-dark\b/;
         if (regex.test(value)) {
           const { light: lightVal, dark: darkVal } = getLightDarkValue(value);

--- a/src/postcss-light-dark.ts
+++ b/src/postcss-light-dark.ts
@@ -1,4 +1,4 @@
-import { atRule as postcssAtRule, decl as postcssDecl, Root } from 'postcss';
+import { atRule as postcssAtRule, Root } from 'postcss';
 
 const FUNCTION = 'light-dark(';
 
@@ -55,9 +55,9 @@ module.exports = () => {
         if (regex.test(value)) {
           const { light: lightVal, dark: darkVal } = getLightDarkValue(value);
           const darkMixin = postcssAtRule({ name: 'mixin', params: 'dark' });
-          darkMixin.append(postcssDecl({ prop, value: darkVal }));
+          darkMixin.append(decl.clone({ value: darkVal }));
           decl.parent?.insertAfter(decl, darkMixin);
-          decl.parent?.insertAfter(decl, postcssDecl({ prop, value: lightVal }));
+          decl.parent?.insertAfter(decl, decl.clone({ value: lightVal }));
 
           decl.remove();
         }


### PR DESCRIPTION
Fixes warning: A PostCSS plugin did not pass the from option to postcss.parse

Small change in the code to use decl.clone to create a new declaration.